### PR TITLE
Setup initial release workflow for submit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           echo $AIRTABLE_BLOCK_REMOTE > .block/remote.json
           echo "{\"airtableApiKey\": \"$AIRTABLE_API_KEY\"}" > .airtableblocksrc.json
           block release
-          block submit
+          block submit > /dev/null 2>&1
 
       - name: Create release
         uses: actions/create-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  submit:
+    name: Submit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+
+      - name: Install dependencies
+        run: |
+          npm ci --prefer-offline --no-audit
+          npm install -g @airtable/blocks-cli
+
+      - name: Submit to Airtable
+        run: |
+          mkdir .block
+          echo $AIRTABLE_BLOCK_REMOTE > .block/remote.json
+          echo "{\"airtableApiKey\": \"$AIRTABLE_API_KEY\"}" > .airtableblocksrc.json
+          block release
+          block submit
+
+      - name: Create release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: false
+          prerelease: false


### PR DESCRIPTION
Closes #8. Creates a GitHub release on version tags. It looks like this should work after a dry-run of commands, but by default `block submit` prints out a form with submission ID pre-filled for inputting details. To be safe, this will need to be hidden